### PR TITLE
Hotfix for duplicate symbol issue with XCode 8 / iOS10

### DIFF
--- a/Surfboard/SRFSurfboard/Panel Data Model/SRFSurfboardPanelType.h
+++ b/Surfboard/SRFSurfboard/Panel Data Model/SRFSurfboardPanelType.h
@@ -13,7 +13,7 @@
  *  A panel type enum - for future use.
  */
 
-NS_ENUM(NSInteger, SRFSurfboardPanelType)
+typedef NS_ENUM(NSInteger, SRFSurfboardPanelType)
 {
     SRFSurfboardPanelDefault = 0    // A panel with a block of text at the top, an image, and an optional button.
 };


### PR DESCRIPTION
One typedef was missing  - caused linker error with duplicate symbols.